### PR TITLE
`breakOn{Exception,Uncaught,None}`

### DIFF
--- a/examples/exceptions.js
+++ b/examples/exceptions.js
@@ -1,0 +1,11 @@
+'use strict';
+let error = null;
+try {
+  throw new Error('Caught');
+} catch (e) {
+  error = e;
+}
+
+if (error) {
+  throw new Error('Uncaught');
+}

--- a/lib/internal/inspect-repl.js
+++ b/lib/internal/inspect-repl.js
@@ -54,6 +54,9 @@ list                  Print the source around the line where execution is curren
 setBreakpoint, sb     Set a breakpoint
 clearBreakpoint, cb   Clear a breakpoint
 breakpoints           List all known breakpoints
+breakOnException      Pause execution whenever an exception is thrown
+breakOnUncaught       Pause execution whenever an exception isn't caught
+breakOnNone           Don't pause on exceptions (this is the default)
 
 watch(expr)           Start watching the given expression
 unwatch(expr)         Stop watching an expression
@@ -222,12 +225,13 @@ function createRepl(inspector) {
   const { Debugger, Runtime } = inspector;
 
   let repl; // eslint-disable-line prefer-const
-  let lastCommand;
 
   // Things we want to keep around
   const history = { control: [], debug: [] };
   const watchedExpressions = [];
   const knownBreakpoints = [];
+  let pauseOnExceptionState = 'none';
+  let lastCommand;
 
   // Things we need to reset when the app restarts
   let knownScripts;
@@ -619,6 +623,13 @@ function createRepl(inspector) {
     });
   }
 
+  function setPauseOnExceptions(state) {
+    return Debugger.setPauseOnExceptions({ state })
+      .then(() => {
+        pauseOnExceptionState = state;
+      });
+  }
+
   Debugger.on('paused', ({ callFrames, reason /* , hitBreakpoints */ }) => {
     // Save execution context's data
     currentBacktrace = Backtrace.from(callFrames);
@@ -787,8 +798,20 @@ function createRepl(inspector) {
       },
 
       scripts: listScripts,
+
       setBreakpoint,
       clearBreakpoint,
+      setPauseOnExceptions,
+      get breakOnException() {
+        return setPauseOnExceptions('all');
+      },
+      get breakOnUncaught() {
+        return setPauseOnExceptions('uncaught');
+      },
+      get breakOnNone() {
+        return setPauseOnExceptions('none');
+      },
+
       list,
     });
     aliasProperties(context, SHORTCUTS);
@@ -818,6 +841,7 @@ function createRepl(inspector) {
 
     inspector.client.on('ready', () => {
       restoreBreakpoints();
+      Debugger.setPauseOnExceptions({ state: pauseOnExceptionState });
     });
 
     return repl;

--- a/test/cli/exceptions.test.js
+++ b/test/cli/exceptions.test.js
@@ -1,0 +1,60 @@
+'use strict';
+const { test } = require('tap');
+
+const startCLI = require('./start-cli');
+
+test('break on (uncaught) exceptions', (t) => {
+  const cli = startCLI(['examples/exceptions.js']);
+
+  function onFatal(error) {
+    cli.quit();
+    throw error;
+  }
+
+  return cli.waitFor(/break/)
+    .then(() => cli.waitForPrompt())
+    .then(() => {
+      t.match(cli.output, 'break in examples/exceptions.js:1');
+    })
+    // making sure it will die by default:
+    .then(() => cli.command('c'))
+    .then(() => cli.waitFor(/disconnect/))
+
+    // Next run: With `breakOnException` it pauses in both places
+    .then(() => cli.stepCommand('r'))
+    .then(() => {
+      t.match(cli.output, 'break in examples/exceptions.js:1');
+    })
+    .then(() => cli.command('breakOnException'))
+    .then(() => cli.stepCommand('c'))
+    .then(() => {
+      t.match(cli.output, 'exception in examples/exceptions.js:4');
+    })
+    .then(() => cli.stepCommand('c'))
+    .then(() => {
+      t.match(cli.output, 'exception in examples/exceptions.js:10');
+    })
+
+    // Next run: With `breakOnUncaught` it only pauses on the 2nd exception
+    .then(() => cli.command('breakOnUncaught'))
+    .then(() => cli.stepCommand('r')) // also, the setting survives the restart
+    .then(() => {
+      t.match(cli.output, 'break in examples/exceptions.js:1');
+    })
+    .then(() => cli.stepCommand('c'))
+    .then(() => {
+      t.match(cli.output, 'exception in examples/exceptions.js:10');
+    })
+
+    // Next run: Back to the initial state! It should die again.
+    .then(() => cli.command('breakOnNone'))
+    .then(() => cli.stepCommand('r'))
+    .then(() => {
+      t.match(cli.output, 'break in examples/exceptions.js:1');
+    })
+    .then(() => cli.command('c'))
+    .then(() => cli.waitFor(/disconnect/))
+
+    .then(() => cli.quit())
+    .then(null, onFatal);
+});

--- a/test/cli/start-cli.js
+++ b/test/cli/start-cli.js
@@ -113,7 +113,7 @@ function startCLI(args) {
       this.flushOutput();
       child.stdin.write(input);
       child.stdin.write('\n');
-      return this.waitFor(/break/)
+      return this.waitFor(/(?:assert|break|debugCommand|exception|other|promiseRejection) in/)
         .then(() => this.waitForPrompt());
     },
 


### PR DESCRIPTION
Fixes https://github.com/buggerjs/node-inspect/issues/6