### PR TITLE
Support for low-level agent access

### DIFF
--- a/lib/internal/inspect-repl.js
+++ b/lib/internal/inspect-repl.js
@@ -730,6 +730,15 @@ function createRepl(inspector) {
   });
 
   function initializeContext(context) {
+    inspector.domainNames.forEach(domain => {
+      Object.defineProperty(context, domain, {
+        value: inspector[domain],
+        enumerable: true,
+        configurable: true,
+        writeable: false,
+      });
+    });
+
     copyOwnProperties(context, {
       get help() {
         print(HELP);

--- a/lib/node-inspect.js
+++ b/lib/node-inspect.js
@@ -66,6 +66,15 @@ function runScript(script, scriptArgs, inspectPort, childPrint) {
 
 function createAgentProxy(domain, client) {
   const agent = new EventEmitter();
+  agent.then = function retrieveDocs(...args) {
+    // TODO: potentially fetch the protocol and pretty-print it here.
+    const descriptor = {
+      [util.inspect.custom](depth, { stylize }) {
+        return stylize(`[Agent ${domain}]`, 'special');
+      },
+    };
+    return Promise.resolve(descriptor).then(...args);
+  };
 
   return new Proxy(agent, {
     get(target, name) {
@@ -95,7 +104,8 @@ class NodeInspector {
 
     this.client = new ProtocolClient(options.port, options.host);
 
-    ['Debugger', 'Runtime'].forEach(domain => {
+    this.domainNames = ['Debugger', 'Runtime'];
+    this.domainNames.forEach(domain => {
       this[domain] = createAgentProxy(domain, this.client);
     });
     this.handleDebugEvent = (fullName, params) => {

--- a/test/cli/low-level.test.js
+++ b/test/cli/low-level.test.js
@@ -1,0 +1,27 @@
+'use strict';
+const { test } = require('tap');
+
+const startCLI = require('./start-cli');
+
+test('Debugger agent direct access', (t) => {
+  const cli = startCLI(['examples/empty.js']);
+
+  function onFatal(error) {
+    cli.quit();
+    throw error;
+  }
+
+  return cli.waitFor(/break/)
+    .then(() => cli.waitForPrompt())
+    .then(() => cli.command('scripts'))
+    .then(() => {
+      const [, scriptId] = cli.output.match(/^\* (\d+): examples\/empty.js/);
+      return cli.command(`Debugger.getScriptSource({ scriptId: '${scriptId}' })`);
+    })
+    .then(() => {
+      t.match(cli.output,
+        'scriptSource: \'(function (exports, require, module, __filename, __dirname) { \\n});\'');
+    })
+    .then(() => cli.quit())
+    .then(null, onFatal);
+});


### PR DESCRIPTION
This allows user to directly access the protocol by exposing the agent proxies inside of the repl context. Because of the existing promise magic, things like the following "just work":

```
> ./cli.js examples/empty.js
# ...
debug> Debugger.getScriptSource({ scriptId: '64' })
{ scriptSource: '(function (exports, require, module, __filename, __dirname) { \n});' }
debug> _.scriptSource
'(function (exports, require, module, __filename, __dirname) { \n});'
```